### PR TITLE
Store calibration data in EEPROM for Teensy boards

### DIFF
--- a/Adafruit_Sensor_Calibration.h
+++ b/Adafruit_Sensor_Calibration.h
@@ -4,7 +4,8 @@
 #include <Adafruit_Sensor.h>
 
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||              \
-    defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(ESP32)
+    defined(__AVR_ATmega2560__) || defined(ESP8266) || defined(ESP32) ||       \
+    defined(TEENSYDUINO)
 #define ADAFRUIT_SENSOR_CALIBRATION_USE_EEPROM
 #else
 #define ADAFRUIT_SENSOR_CALIBRATION_USE_SDFAT


### PR DESCRIPTION
This change will select EEPROM for storing calibration data if run on a Teensy board (if `TEENSYDUINO` is defined). Previously, Teensys would not be detected so the SDFat code would be used instead, which doesn't work if no SD card or flash chip is connected. The change makes this library work on my Teensy 3.0.