### PR TITLE
Added O_TRUNC flag to file open to allow overwrite. Address issue #5

### DIFF
--- a/Adafruit_Sensor_Calibration_SDFat.cpp
+++ b/Adafruit_Sensor_Calibration_SDFat.cpp
@@ -96,7 +96,7 @@ bool Adafruit_Sensor_Calibration_SDFat::saveCalibration(void) {
   if (!theFS)
     return false;
 
-  File file = theFS->open(_cal_filename, O_WRITE | O_CREAT);
+  File file = theFS->open(_cal_filename, O_WRITE | O_CREAT | O_TRUNC);
   if (!file) {
     Serial.println(F("Failed to create file"));
     return false;


### PR DESCRIPTION
As noted in Issue #5 attempting to save calibration when there already is an existing calibration results in a silent failure. This fix addresses the issue by adding the O_TRUNC flag to the file open. From [documentation](https://man7.org/linux/man-pages/man2/open.2.html)  my understanding is that this will result in a file overwrite.